### PR TITLE
Gradle build, canary unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Scooter-User-Generator
 Java App. Queries Meetup to get the event list
 
-# Usage
-Run generator, and passes in 3 arguments. Group Name, meetup date and private key.
+# To Build
+* install [Gradle](http://gradle.org/gradle-download/)
+* type 'gradle scooterBuild'
+
+# To Run
+* if built with Gradle, 'cd staging'
+* Run generator with 3 arguments: Group Name, meetup date and private key
+* example: java -jar ScooterUserGenerator.jar PEI-Developers 2015-10-08 API_KEY 
 
 Example 
 ```Batchfile

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,59 @@
+
+apply plugin: 'java'
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src'
+        }
+    }
+    test {
+        java { 
+            srcDir 'test'
+        }
+    }
+}
+
+configurations {
+    releaseJars
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'com.google.code.gson:gson:2.3.1'
+
+    testCompile 'junit:junit:4.11'
+   
+    releaseJars 'com.google.code.gson:gson:2.3.1'
+}
+
+task init {
+    delete "${buildDir}/jars"
+    mkdir "${buildDir}/jars"
+    delete stagingDir
+    mkdir stagingDir
+}
+
+task copyReleaseJars(type: Copy, dependsOn: 'init') {
+    into "${buildDir}/jars"
+    from configurations.releaseJars
+}
+
+jar.archiveName 'ScooterUserGenerator.jar'
+jar.manifest {
+    attributes 'Main-Class' : 'Generator' 
+    attributes 'Class-Path' : 'jars/gson-2.3.1.jar '
+}
+
+task scooterBuild(dependsOn: ['test', 'copyReleaseJars', 'jar']) << {
+    ant.zip(destfile: "${buildDir}/ScooterUserGenerator.zip") {
+        zipfileset(dir: "${buildDir}/jars", prefix: "jars")
+        zipfileset(file: "${buildDir}/libs/ScooterUserGenerator.jar")
+    }
+
+    ant.unzip(src: "${buildDir}/ScooterUserGenerator.zip", dest: project.stagingDir)
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+stagingDir=staging

--- a/test/ca/peidevs/formatter/ScooterDojoFormatterTestCase.java
+++ b/test/ca/peidevs/formatter/ScooterDojoFormatterTestCase.java
@@ -1,0 +1,13 @@
+
+package ca.peidevs.formatter;
+
+import static org.junit.Assert.*;
+import java.util.*;
+import org.junit.*;
+
+public class ScooterDojoFormatterTestCase {
+   @Test
+   public void testCanary() {
+       assertEquals(4, 2+2);
+   }
+}


### PR DESCRIPTION
- new Gradle build with basic unit test
- if using Gradle, dependency management (e.g. gson) and classpath is automated
- the ReadMe is a bit messy we could fix it up later with 2 sections: with Gradle and without Gradle (it wasn't clear what was being used ... presumably an IDE?)
